### PR TITLE
B2C billing now MAU-based

### DIFF
--- a/docs/auth/index.md
+++ b/docs/auth/index.md
@@ -72,7 +72,7 @@ Using App Center Auth has the following limitations in preview:
 
 ## Pricing
 
-App Center Auth is a free service, but you pay for [Azure AD B2C authentications](https://azure.microsoft.com/pricing/details/active-directory-b2c/). The first 50,000 authentications per month are free. An authentication is defined as a token issued either in response to a sign-in request initiated by a user, or initiated by an application on behalf of a user (e.g. token refresh, where the refresh interval is configurable). It is free to store authenticated users in the Azure AD B2C tenant. If you turn on **Multi-Factor Authentication**, you will be charged at a flat fee of $0.03 per authentication.
+App Center Auth is a free service, but you pay for [Azure AD B2C authentications](https://azure.microsoft.com/pricing/details/active-directory-b2c/). The first 50,000 monthly active users (MAU) are free. A MAU is counted when a unique user authenticates within a given calendar month. It is free to store authenticated users in the Azure AD B2C tenant. If you turn on **Multi-Factor Authentication**, you will be charged at a flat fee of $0.03 per authentication.
 
 ## Getting Started
 


### PR DESCRIPTION
Updating the **Pricing** section with [monthly active users (MAU) billing](https://docs.microsoft.com/azure/active-directory-b2c/active-directory-b2c-how-to-enable-billing#monthly-active-users-mau-billing) which went into effect on 01 NOV 2019.